### PR TITLE
Add assert statements

### DIFF
--- a/src/main/java/duke/command/AddCommand.java
+++ b/src/main/java/duke/command/AddCommand.java
@@ -12,7 +12,7 @@ import duke.util.Ui;
 public class AddCommand extends Command {
 
     public static final String COMMAND_WORD = "add";
-    private final Task task;
+    private Task task;
 
     /**
      * Constructor for AddCommand which adds the provided task.
@@ -25,9 +25,11 @@ public class AddCommand extends Command {
 
     /**
      * Executes command by adding task into Duke.Duke.util.TaskList.
+     *
      * @param taskList  List of tasks
      * @param ui        Ui provided
      * @param storage   Saved history
+     * @return message to tell user that task has been added
      */
     @Override
     public String execute(TaskList taskList, Ui ui, Storage storage) throws DukeException {

--- a/src/main/java/duke/command/ByeCommand.java
+++ b/src/main/java/duke/command/ByeCommand.java
@@ -14,9 +14,11 @@ public class ByeCommand extends Command {
 
     /**
      * Executes command by printing exit message.
+     *
      * @param taskList List of tasks.
      * @param ui       Ui provided.
      * @param storage  Saved history.
+     * @return message to tell user that chat-bot program has been terminated.
      */
     @Override
     public String execute(TaskList taskList, Ui ui, Storage storage) throws DukeException {

--- a/src/main/java/duke/command/Command.java
+++ b/src/main/java/duke/command/Command.java
@@ -12,9 +12,11 @@ public abstract class Command {
 
     /**
      * Executes command by printing exit message.
+     *
      * @param taskList  List of tasks
      * @param ui        Ui provided
      * @param storage   Saved history
+     * @return message that tells user action requested has been taken
      */
     public abstract String execute(TaskList taskList, Ui ui, Storage storage) throws DukeException;
 

--- a/src/main/java/duke/command/DeleteCommand.java
+++ b/src/main/java/duke/command/DeleteCommand.java
@@ -11,7 +11,7 @@ import duke.util.Ui;
 public class DeleteCommand extends Command {
 
     public static final String COMMAND_WORD = "delete";
-    private final int taskIndex;
+    private int taskIndex;
 
     /**
      * Constructor for DeleteCommand which provides an index to delete.
@@ -25,9 +25,11 @@ public class DeleteCommand extends Command {
 
     /**
      * Executes command by printing exit message.
+     *
      * @param taskList List of tasks.
      * @param ui       Ui provided.
      * @param storage  Saved history.
+     * @return message to tell user that task has been deleted
      */
     @Override
     public String execute(TaskList taskList, Ui ui, Storage storage) throws DukeException {

--- a/src/main/java/duke/command/FindCommand.java
+++ b/src/main/java/duke/command/FindCommand.java
@@ -12,7 +12,7 @@ import duke.util.Ui;
 public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
-    private final String keyword;
+    private String keyword;
 
 
     /**
@@ -26,9 +26,11 @@ public class FindCommand extends Command {
 
     /**
      * Executes command by adding task into Duke.Duke.util.TaskList.
+     *
      * @param taskList List of tasks
      * @param ui       Ui provided
      * @param storage  Saved history
+     * @return message to tell user of the tasks matching with keyword given
      */
     @Override
     public String execute(TaskList taskList, Ui ui, Storage storage) throws DukeException {

--- a/src/main/java/duke/command/ListCommand.java
+++ b/src/main/java/duke/command/ListCommand.java
@@ -14,9 +14,11 @@ public class ListCommand extends Command {
 
     /**
      * Executes command by adding task into Duke.Duke.util.TaskList.
+     *
      * @param taskList List of tasks
      * @param ui       Ui provided
      * @param storage  Saved history
+     * @return message to tell user of the outstanding tasks in the list
      */
     @Override
     public String execute(TaskList taskList, Ui ui, Storage storage) throws DukeException {

--- a/src/main/java/duke/command/MarkCommand.java
+++ b/src/main/java/duke/command/MarkCommand.java
@@ -24,9 +24,11 @@ public class MarkCommand extends Command {
 
     /**
      * Executes command by marking task in TaskList.
+     *
      * @param taskList  List of tasks
      * @param ui        Ui provided
      * @param storage   Saved history
+     * @return message to tell user that task has been marked
      */
     @Override
     public String execute(TaskList taskList, Ui ui, Storage storage) throws DukeException {

--- a/src/main/java/duke/command/UnmarkCommand.java
+++ b/src/main/java/duke/command/UnmarkCommand.java
@@ -24,9 +24,11 @@ public class UnmarkCommand extends Command {
 
     /**
      * Executes command by unmarking task in TaskList.
+     *
      * @param taskList List of tasks
      * @param ui       Ui provided
      * @param storage  Saved history
+     * @return message to tell user that task has been unmarked
      */
     @Override
     public String execute(TaskList taskList, Ui ui, Storage storage) throws DukeException {

--- a/src/main/java/duke/gui/Main.java
+++ b/src/main/java/duke/gui/Main.java
@@ -1,6 +1,7 @@
 package duke.gui;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import duke.Duke;
 import javafx.application.Application;
@@ -16,7 +17,8 @@ import javafx.stage.Stage;
 public class Main extends Application {
 
     private final Duke duke = new Duke();
-    private final Image appImage = new Image(this.getClass().getResourceAsStream("/images/pirate.png"));
+    private final Image appImage = new Image(
+            Objects.requireNonNull(this.getClass().getResourceAsStream("/images/pirate.png")));
 
     @Override
     public void start(Stage stage) {

--- a/src/main/java/duke/gui/MainWindow.java
+++ b/src/main/java/duke/gui/MainWindow.java
@@ -13,6 +13,8 @@ import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
 
+import java.util.Objects;
+
 /**
  * Controller for MainWindow. Provides the layout for the other controls.
  */
@@ -30,10 +32,14 @@ public class MainWindow extends AnchorPane {
     private Stage stage;
     private static final Ui ui = new Ui();
 
-    private final Image userImage = new Image(this.getClass().getResourceAsStream("/images/DaUser.png"));
-    private final Image dukeImage = new Image(this.getClass().getResourceAsStream("/images/DaDuke.png"));
-    private final Image welcomeGif = new Image(this.getClass().getResourceAsStream("/images/jack_sparrow_welcome.gif"));
-    private final Image exitGif = new Image(this.getClass().getResourceAsStream("/images/jack_sparrow_adios.gif"));
+    private final Image userImage = new Image(
+            Objects.requireNonNull(this.getClass().getResourceAsStream("/images/DaUser.png")));
+    private final Image dukeImage = new Image(
+            Objects.requireNonNull(this.getClass().getResourceAsStream("/images/DaDuke.png")));
+    private final Image welcomeGif = new Image(
+            Objects.requireNonNull(this.getClass().getResourceAsStream("/images/jack_sparrow_welcome.gif")));
+    private final Image exitGif = new Image(
+            Objects.requireNonNull(this.getClass().getResourceAsStream("/images/jack_sparrow_adios.gif")));
 
     @FXML
     public void initialize() {

--- a/src/main/java/duke/task/Task.java
+++ b/src/main/java/duke/task/Task.java
@@ -18,7 +18,8 @@ public abstract class Task {
     }
 
     public String getStatusIcon() {
-        return (isDone ? "X" : " "); // mark done task with X
+        // mark done task with X
+        return (isDone ? "X" : " ");
     }
     public String getTaskDescription() {
         return this.description;

--- a/src/main/java/duke/util/Storage.java
+++ b/src/main/java/duke/util/Storage.java
@@ -19,6 +19,8 @@ public class Storage {
     /**
      * Creates a new instance of Storage that loads the history from a specific path
      * or creates a new file for saving tasks
+     *
+     * @param filePath File path where file stores the task list
      */
     public Storage(String filePath) {
         Storage.filePath = filePath;
@@ -63,6 +65,8 @@ public class Storage {
 
     /**
      * Save all tasks into a file
+     *
+     * @param taskList list of tasks
      */
     public static void saveToFile(ArrayList<Task> taskList) {
         String result = "";

--- a/src/main/java/duke/util/TaskList.java
+++ b/src/main/java/duke/util/TaskList.java
@@ -18,7 +18,7 @@ import duke.task.Todo;
 public class TaskList {
 
     private static final String TASK_ADDED = "Task Added, arrgh:\n";
-    private final ArrayList<Task> taskList;
+    private ArrayList<Task> taskList;
     private int taskCount = 0;
     private Ui ui = new Ui();
 
@@ -78,9 +78,11 @@ public class TaskList {
      * Adds a task into list of tasks.
      *
      * @param task List of tasks.
+     * @return message to tell user that task has been added
      */
     public String add(Task task) {
         StringBuilder str = new StringBuilder();
+        int numOfTasksBeforeAddition = taskList.size();
         if (task != null) {
             this.taskList.add(task);
             this.taskCount++;
@@ -88,6 +90,7 @@ public class TaskList {
             str.append("\nNow you have " + this.taskCount
                     + " tasks in your task list arrr, better get workin' aye!\n");
             str.append(ui.requestNextCommand());
+            assert numOfTasksBeforeAddition + 1 == taskList.size() : "Task should be added to task list";
             return str.toString();
         } else {
             str.append(ui.showError("\tTask is invalid matey :-(, please try again!\n"));
@@ -99,14 +102,17 @@ public class TaskList {
      * Deletes a task from list of tasks.
      *
      * @param taskIndex 0-based index task number to be deleted.
+     * @return message to tell user that task has been deleted
      */
     public String delete(int taskIndex) {
-        StringBuilder str = new StringBuilder();
+        StringBuilder str = new StringBuilder();.
+        int numOfTasksBeforeDeletion = taskList.size();
         try {
             Task task = taskList.get(taskIndex);
             this.taskList.remove(taskIndex);
             this.taskCount--;
-            str.append(ui.deleteTask() + task+ "\n" + ui.requestNextCommand());
+            str.append(ui.deleteTask() + task + "\n" + ui.requestNextCommand());
+            assert numOfTasksBeforeDeletion + 1 == taskList.size() : "Task should be added to task list";
             return str.toString();
         } catch (IndexOutOfBoundsException e) {
             ui.showError("\tAin't nuthin' to be deleted here matey! :-(\n");
@@ -118,6 +124,7 @@ public class TaskList {
      * Finds a task or tasks that matches the given keyword
      *
      * @param keyword keyword to be found in list of tasks
+     * @return message to tell user of the tasks matching with keyword given
      */
     public String findTaskMatchingKeyword(String keyword) {
 
@@ -164,10 +171,18 @@ public class TaskList {
      * Mark a task in list of tasks as done
      *
      * @param taskIndex 0-based index of task number.
+     *
+     */
+    /**
+     * Mark a task in list of tasks as done
+     *
+     * @param taskIndex taskIndex 0-based index of task number.
+     * @return message to tell user that task has been marked
      */
     public String markTask(int taskIndex) {
         StringBuilder str = new StringBuilder();
         Task curr = taskList.get(taskIndex);
+        assert curr != null : "Task does not exist";
         curr.markAsDone();
         str.append(ui.markAsDone() + curr + "\n" + ui.requestNextCommand());
 
@@ -178,10 +193,12 @@ public class TaskList {
      * Mark a task in list of tasks as not done
      *
      * @param taskIndex 0-based index of task number.
+     * @return message to tell user that task has been unmarked
      */
     public String unmarkTask(int taskIndex) {
         StringBuilder str = new StringBuilder();
         Task curr = taskList.get(taskIndex);
+        assert curr != null : "Task does not exist";
         curr.markAsUndone();
         str.append(ui.markAsUndone() + curr + "\n" + ui.requestNextCommand());
 
@@ -190,6 +207,8 @@ public class TaskList {
 
     /**
      * Prints out the list of outstanding tasks
+     *
+     * @return message to tell user of the outstanding tasks in the list
      */
     public String printTaskList() {
         StringBuilder str = new StringBuilder();


### PR DESCRIPTION
Modify code for better readibility

Some methods' Javadoc comments are too close together and missing
some tags.

Javadoc comments being too close together made it difficult to read
description and missing tags cause users not to be aware of what the
method with the missing return tag, return value is.

Adding whitespaces between Javadoc method description and params
tag to help with better code readibility. Add missing return tags
for methods to ensure users know the what each method returns.